### PR TITLE
Add android_frameworks_base repo

### DIFF
--- a/clone_all.sh
+++ b/clone_all.sh
@@ -13,6 +13,7 @@ declare -A repos=(
     ["android_packages_apps_FairphoneLauncher3"]="platform/packages/apps/FairphoneLauncher3"
     ["android_packages_apps_MyContactsWidget"]="platform/packages/apps/MyContactsWidget"
     ["android_packages_apps_ClockWidget"]="platform/packages/apps/ClockWidget"
+    ["android_frameworks_base"]="platform/frameworks/base"
     )
 
 for repo in ${!repos[@]}; do


### PR DESCRIPTION
It would be great to have it here for reference.

There is work being done at @WeAreFairphone to backport Fairphone OS's lockscreen clock widget functionality (at `packages/Keyguard`) to the standalone Clock Widget.